### PR TITLE
Update security notice now HTTPS is used

### DIFF
--- a/packages/pixelartacademy/pages/home/home.html
+++ b/packages/pixelartacademy/pages/home/home.html
@@ -9,14 +9,10 @@
   <hr/>
   <p>Things to keep in mind:</p>
   <ul>
-    <li><strong>Security</strong>: Webpage is for now running over an unsecure http protocol. I you are on a public network such as a cafe
-      or a dorm wi-fi,
-      someone could potentially listen and hijack the communication between your browser and the server. It's unlikely,
-      especially since there's no information to 'steal' yet, but I just wanted a disclaimer out there. So it's up to
-      you not to store any sensitive information in there until I upgrade to https. And you probably shouldn't even later on. Otherwise all the data is safely stored to the best of my knowledge (you are welcome to
-      analyze the
-      <a href="https://github.com/retronator" target="_blank">source
-        code</a>).
+    <li><strong>Security</strong>: Webpage is for now running over the secure https protocol.
+      All the data is safely stored to the best of my knowledge (you are welcome to analyze the
+      <a href="https://github.com/retronator" target="_blank">source code</a>).
+      Eventhough the connection and data are secure now,  it's still up to you not to store any sensitive information in here.
     </li>
     <li><strong>User data</strong>: I don't guarantee that any user/character data won't get wiped at some point or another during the
       alpha. Please don't use the alpha to build a portfolio to show to clients (yet). It's a playground to see the tech while it's


### PR DESCRIPTION
I update the security notice on the landing page to reflect the change to https.
I tried to keep a similar message: do not store sensitive data (even though https is used)
