### PR TITLE
Fix shortname of gates

### DIFF
--- a/packages/retropolis-spaceport/airportterminal/concourse/gates/gates.coffee
+++ b/packages/retropolis-spaceport/airportterminal/concourse/gates/gates.coffee
@@ -12,7 +12,7 @@ class RS.AirportTerminal.Gates extends LOI.Adventure.Location
   @version: -> '0.0.1'
 
   @fullName: -> "Airport terminal gate"
-  @shortName: -> "concourse"
+  @shortName: -> "gates"
   @description: ->
     "
       You are at the airport gates that allow passengers to board the planes. All doors are closed as the


### PR DESCRIPTION
At the concourse one of the exits shows as 'concourse' when you go to this location, you end up at the gates.

This (untested) PR is supposed to change the exit to 'gates' (assuming I understood the engine mechanics correctly)