### PR TITLE
get shader code to compile again

### DIFF
--- a/packages/artificialengines/pyramid/complexnumber.glsl
+++ b/packages/artificialengines/pyramid/complexnumber.glsl
@@ -7,7 +7,7 @@ struct ComplexNumber {
   float imaginary;
 };
 
-float abs(const ComplexNumber a) {
+float complexAbs(const ComplexNumber a) {
   return sqrt(pow2(a.real) + pow2(a.imaginary));
 }
 
@@ -74,8 +74,8 @@ ComplexNumber pow2(const ComplexNumber a) {
   return multiply(a, a);
 }
 
-ComplexNumber sqrt(const ComplexNumber a) {
-  float absoluteValue = abs(a);
+ComplexNumber complexSqrt(const ComplexNumber a) {
+  float absoluteValue = complexAbs(a);
   float imaginarySign = a.imaginary >= 0.0 ? 1.0 : -1.0;
 
   return ComplexNumber(
@@ -86,7 +86,7 @@ ComplexNumber sqrt(const ComplexNumber a) {
 
 ComplexNumber complexLog(const ComplexNumber a) {
   return ComplexNumber(
-    log(abs(a)),
+    log(complexAbs(a)),
     argument(a)
   );
 }
@@ -108,7 +108,7 @@ ComplexNumber complexCos(const ComplexNumber a) {
 ComplexNumber complexAsin(const ComplexNumber a) {
   ComplexNumber i = ComplexNumber(0.0, 1.0);
   ComplexNumber minusI = ComplexNumber(0.0, -1.0);
-  return multiply(minusI, complexLog(add(multiply(i, a), sqrt(subtract(1.0, pow2(a))))));
+  return multiply(minusI, complexLog(add(multiply(i, a), complexSqrt(subtract(1.0, pow2(a))))));
 }
 
 #endif

--- a/packages/artificialengines/reality/optics/fresnelequations.glsl
+++ b/packages/artificialengines/reality/optics/fresnelequations.glsl
@@ -18,8 +18,8 @@ float FresnelEquations_getReflectance(const float angleOfIncidence, const Comple
   ComplexNumber n1cosJ = multiply(n1, cosJ);
   ComplexNumber n2cosI = multiply(n2, cosI);
 
-  float reflectanceS = pow2(abs(divide(subtract(n1cosI, n2cosJ), add(n1cosI, n2cosJ))));
-  float reflectanceP = pow2(abs(divide(subtract(n1cosJ, n2cosI), add(n1cosJ, n2cosI))));
+  float reflectanceS = pow2(complexAbs(divide(subtract(n1cosI, n2cosJ), add(n1cosI, n2cosJ))));
+  float reflectanceP = pow2(complexAbs(divide(subtract(n1cosJ, n2cosI), add(n1cosJ, n2cosI))));
 
   return (reflectanceS + reflectanceP) / 2.0;
 }


### PR DESCRIPTION
compilation of the mesh editor branch failed because some custom shader functions conflict with intrinsic shader functions, had to rename them following the same pattern used to resolve similar name conflicts on other functions